### PR TITLE
Убрал config.eager_load предупреждения

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,9 @@ Rusrails::Application.configure do
   # since you don't have to restart the webserver when you make code changes.
   config.cache_classes = false
 
+  # Do not eager load code on boot.
+  config.eager_load = false
+
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,6 +5,12 @@ Rusrails::Application.configure do
   # Code is not reloaded between requests
   config.cache_classes = true
 
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both thread web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+  
   # Full error reports are disabled and caching is turned on
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,11 @@ Rusrails::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+  
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false


### PR DESCRIPTION
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:
- development - set it to false
- test - set it to false (unless you use a tool that preloads your test environment)
- production - set it to true
