### PR TITLE
[issue 172] change brush for 'erb' code

### DIFF
--- a/lib/renderers/markdown.rb
+++ b/lib/renderers/markdown.rb
@@ -100,7 +100,7 @@ HTML
         when 'ruby', 'sql', 'plain'
           code_type
         when 'erb'
-          'ruby; html-script: true'
+          'ruby'
         when 'html'
           'xml' # html is understood, but there are .xml rules in the CSS
         else


### PR DESCRIPTION
Решение для [Issue#172](https://github.com/morsbox/rusrails/issues/172)
Всем привет. 
Посмотрел код, у меня локально добавляются еще и пробелы, помимо пустой строки в конце. Вообще, после первого появления `erb`-обозначения кода все последующие, даже для `ruby`, отображаются криво.
Будут мысли - готов поправить код.