### PR TITLE
fix code highlighter

### DIFF
--- a/vendor/assets/stylesheets/shThemeRailsGuides.css
+++ b/vendor/assets/stylesheets/shThemeRailsGuides.css
@@ -6,6 +6,7 @@
   font-family: "Anonymous Pro", "Inconsolata", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace !important;
   overflow-y: hidden !important;
   overflow-x: auto !important;
+  padding-bottom: 2px;
 }
 .syntaxhighlighter .line.alt1 {
   background-color: #eee !important;


### PR DESCRIPTION
Исправил баг, при котором сейчас не отображается в некоторых местах кода нижнее подчеркивание.

![alt text](http://image.ibb.co/cBw15v/2017_06_01_23_21_25.png "Logo Title Text 1")


![alt text](http://image.ibb.co/kPzM5v/2017_06_01_23_21_161.png "Logo Title Text 1")