### PR TITLE
missing space added

### DIFF
--- a/source/upgrading_ruby_on_rails.md
+++ b/source/upgrading_ruby_on_rails.md
@@ -202,7 +202,7 @@ Rails.autoloaders.main.preload(sti_leaves)
 Теперь можно без проблем использовать пути констант в определениях класса и модуля:
 
 ```ruby
-# Автозагрузка в телеэтого класса теперь соответствует семантике Ruby.
+# Автозагрузка в теле этого класса теперь соответствует семантике Ruby.
 class Admin::UsersController < ApplicationController
   # ...
 end


### PR DESCRIPTION
Добавлен пропущеный пробел в тексте на странице апгрейда Rails