### PR TITLE
Fix code block formatting in active_record_validations.md

### DIFF
--- a/source/active_record_validations.md
+++ b/source/active_record_validations.md
@@ -516,7 +516,7 @@ NOTE: Ошибки, добавляемые в `record.errors[:base]` относ�
 ```ruby
 class GoodnessValidator < ActiveModel::Validator
   def validate(record)
-    if options[:fields].any?{|field| record.send(field) == "Evil" }
+    if options[:fields].any? { |field| record.send(field) == "Evil" }
       record.errors[:base] << "This person is evil"
     end
   end


### PR DESCRIPTION
Так реализовано и в https://github.com/rails/rails/blob/7c32f09c4a390aa7876dd671a3778c3034c081c4/guides/source/active_record_validations.md#validates_with

А, на сайте https://guides.rubyonrails.org/ у них тоже опечатка.