### PR TITLE
Update .yaspeller.json

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -264,5 +264,6 @@
     "экшн(а|е|у|ы|ах|ов|ом|ам|ами|)",
     "экранизатор(а|е|у|ы|ах|ов|ом|ами|)"
   ],
-  "ignoreCapitalization": true
+  "ignoreCapitalization": true,
+  "byWords":true
 }


### PR DESCRIPTION
[issue 441](https://github.com/morsbox/rusrails/issues/441)  Проблема связана с тем, что используется "контекст". Т.е чтобы добиться ожидаемого поведения необходимо рассматривать `к ассету`  как 2 отдельных слова, а не словосочетание.
Для этого можно вызвать  `yaspeller` с параметром `--by-words` (можно указать в `.yaspeller.json`).
Fixes #441 